### PR TITLE
Fix: deleting vms

### DIFF
--- a/vm_operations.cpp
+++ b/vm_operations.cpp
@@ -149,9 +149,10 @@ void save_vm() {
 void shutdown_vm() {
     string shutdown_cmd = "sudo virsh shutdown " + ship_env.name; 
     system(shutdown_cmd.c_str()); 
-    string state = get_vm_state(ship_env.name);
-
-    if (state.find("running") != string::npos || state.find("paused") != string::npos) {
+    
+    string shutdown_signal = "sudo virsh event --event lifecycle --timeout 5 " + ship_env.name;
+    bool timeout = system(shutdown_signal.c_str());
+    if (timeout) {
         cout << "The VM isnt responding do you want to forcefully shutdown the vm ? (y/n): ";
         string confirm;
         getline(cin, confirm);


### PR DESCRIPTION
## Issue being fixed
This PR fixes issue #4 .

## Description
Since the shutdown command is asynchronous, the application wont' wait for the correct termination of the vm and would immediately query It's status, without giving the vm enough time to properly shutoff. On my machine (i5-6500) It takes at least 3 seconds for a full shutdown but the amount of time may vary greatly depending on the programs installed on the vm that need to be closed.

## Solution
The application can subscribe to a lifecycle event and wait for a signal. I added a timeout of 5 seconds, after which the application would prompt the user for an hard shutdown.

## Testing
I tested the changes locally on my machine